### PR TITLE
Add dependabot check for actions & gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "03:00"
+    timezone: "Etc/UTC"
+  open-pull-requests-limit: 100
+  reviewers:
+  - planetf1
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "03:00"
+    timezone: "Etc/UTC"
+  open-pull-requests-limit: 10
+  reviewers:
+  - planetf1


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds missing dependabot check for github actions & gradle code