### PR TITLE
#24 Update versioning approach for container image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -59,9 +59,10 @@ jobs:
       # egeria-configure needs to install utilities
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      - name: Set Release version env variable
+      - name: Set Release version env variables
         run: |
           echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
       - name: Build and push to quay.io and docker.io (tag latest only for main!)
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: docker/build-push-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Set Release version env variable
         run: |
           echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
       - name: Build and push( to quay.io and docker.io (no tag latest)
         uses: docker/build-push-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project
 
-ARG version=latest
-ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria
+# This is the EGERIA version - typically passed from the ci/cd pipeline
+ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria:latest
+
 # DEFER setting this for now, using the ${version}:
 # ARG EGERIA_IMAGE_DEFAULT_TAG=latest
 
@@ -10,16 +11,15 @@ ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria
 # ie
 # docker -f ./Dockerfile
 
-FROM ${EGERIA_BASE_IMAGE}:${version}
-
-ENV version ${version}
+FROM ${EGERIA_BASE_IMAGE}
 
 # Labels from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys (with additions prefixed    ext)
 # We should inherit all the base labels from the egeria image and only overwrite what is necessary.
 LABEL org.opencontainers.image.description = "Egeria with Strimzi connector" \
       org.opencontainers.image.documentation = "https://github.com/odpi/egeria-connector-integration-event-schema"
 
-COPY build/libs/egeria-connector-integration-event-schema-${version}*.jar /deployments/server/lib
+# This assumes we only have one uber jar (ensure old versions cleaned out beforehand). Avoids having to pass connector version
+COPY build/libs/egeria-connector-integration-event-schema-*-with-dependencies.jar /deployments/server/lib
 
 # Uncomment to enable Java remote debugging
 # ENV JAVA_DEBUG 1


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fixes to container build
* Egeria version defaults to quay.io/odpi/egeria:latest, however this will always be set in the build pipeline based on the dependency version of the open connector framework. This ensures the base image matches the intent of the connector developer
* The container version is pulled from the project version