### PR TITLE
#24 Pin docker build context for ci/cd workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -67,6 +67,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-integration-event-schema:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-event-schema:latest
           platforms: linux/amd64,linux/arm64
@@ -74,6 +75,7 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main'}}
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-event-schema:${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Build and push( to quay.io and docker.io (no tag latest)
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-event-schema:${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,13 @@
 # This is the EGERIA version - typically passed from the ci/cd pipeline
 ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria:latest
 
-# DEFER setting this for now, using the ${version}:
-# ARG EGERIA_IMAGE_DEFAULT_TAG=latest
-
-# This Dockerfile should be run from the parent directory
-# ie
-# docker -f ./Dockerfile
-
 FROM ${EGERIA_BASE_IMAGE}
 
 # Labels from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys (with additions prefixed    ext)
 # We should inherit all the base labels from the egeria image and only overwrite what is necessary.
-LABEL org.opencontainers.image.description = "Egeria with Strimzi connector" \
+LABEL org.opencontainers.image.description = "Egeria with Event Schema connector" \
       org.opencontainers.image.documentation = "https://github.com/odpi/egeria-connector-integration-event-schema"
 
 # This assumes we only have one uber jar (ensure old versions cleaned out beforehand). Avoids having to pass connector version
 COPY build/libs/egeria-connector-integration-event-schema-*-with-dependencies.jar /deployments/server/lib
 
-# Uncomment to enable Java remote debugging
-# ENV JAVA_DEBUG 1


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Specifically sets docker build context so that built libraries can be included (default within github action is a temp directory)
* Corrects incorrect name in metadata